### PR TITLE
Implemented trade verification

### DIFF
--- a/api/controllers/ReferenceController.js
+++ b/api/controllers/ReferenceController.js
@@ -220,6 +220,40 @@ module.exports = {
             return res.ok(ref);
           });
         }
+        if (ref.type === 'casual' || ref.type === 'shiny' || ref.type === 'event') {
+          User.findOne({name: ref.user2.substring(3)}, function(err, otherUser) {
+            if (!otherUser) {
+              return;
+            }
+            var query = {
+              url: new RegExp(ref.url.substring(ref.url.indexOf("/r/"))),
+              user2: '/u/' + refUser.name,
+              $or: [
+                {type: 'casual'},
+                {type: 'shiny'},
+                {type: 'event'}
+              ],
+            };
+            Reference.findOne(query, function (err, otherRef) {
+              if (!otherRef) {
+                return;
+              }
+              otherRef.approved = approve;
+              ref.verified = approve;
+              otherRef.verified = approve;
+              ref.save(function (err) {
+                if (err) {
+                  console.log(err);
+                }
+              });
+              otherRef.save(function (err) {
+                if (err) {
+                  console.log(err);
+                }
+              });
+            });
+          });
+        }
       });
     });
   },

--- a/api/controllers/ReferenceController.js
+++ b/api/controllers/ReferenceController.js
@@ -224,10 +224,6 @@ module.exports = {
   },
 
   approve: function (req, res) {
-    if (!req.user.isMod) {
-      return res.json("Not a mod", 403);
-    }
-
     var id = req.allParams().id,
       approve = req.allParams().approve;
 
@@ -239,17 +235,13 @@ module.exports = {
         References.approve(ref, refUser.name, approve).then(function (result) {
           return res.status(200).json(ref);
         }, function (error) {
-          return res.json(error);
+          return res.status(500).json(error);
         });
       });
     });
   },
 
   approveAll: function (req, res) {
-    if (!req.user.isMod) {
-      return res.json("Not a mod", 403);
-    }
-
     User.findOne({id: req.allParams().userid}, function (err, refUser) {
       if (!refUser) {
         return res.notFound("User not found");

--- a/api/controllers/ReferenceController.js
+++ b/api/controllers/ReferenceController.js
@@ -259,7 +259,6 @@ module.exports = {
         if (err) {
           return res.serverError(err);
         }
-        console.log(refs);
         for (var i = 0; i < refs.length; i++) {
           promises.push(References.approve(refs[i], refUser.name, true));
         }

--- a/api/models/Reference.js
+++ b/api/models/Reference.js
@@ -34,7 +34,7 @@ module.exports = {
         "misc"
       ]
     },
-    // This defines whether the other user has added the same url
+    // This is true if the other user has added the same url, and the trade has been approved.
     verified: "boolean",
     // This defines if the mods have approved it as a trade that can count
     approved: "boolean",

--- a/api/services/References.js
+++ b/api/services/References.js
@@ -1,0 +1,49 @@
+exports.approve = function (ref, name, approve) {
+  return new Promise(function (resolve, reject) {
+    if (!ref) {
+      return reject({statusCode: 404});
+    }
+    ref.approved = approve;
+    ref.save(function (err) {
+      if (err) {
+        return reject({statusCode: 500});
+      }
+      return resolve({statusCode: 200});
+    });
+    if (ref.type === 'casual' || ref.type === 'shiny' || ref.type === 'event') {
+      User.findOne({name: ref.user2.substring(3)}, function(err, otherUser) {
+        if (!otherUser) {
+          return;
+        }
+        var query = {
+          user: otherUser.id,
+          url: new RegExp(ref.url.substring(ref.url.indexOf("/r/"))),
+          user2: '/u/' + name,
+          $or: [
+            {type: 'casual'},
+            {type: 'shiny'},
+            {type: 'event'}
+          ],
+        };
+        Reference.findOne(query, function (err, otherRef) {
+          if (!otherRef) {
+            return;
+          }
+          otherRef.approved = approve;
+          ref.verified = approve;
+          otherRef.verified = approve;
+          ref.save(function (err) {
+            if (err) {
+              console.log(err);
+            }
+          });
+          otherRef.save(function (err) {
+            if (err) {
+              console.log(err);
+            }
+          });
+        });
+      });
+    }
+  });
+};

--- a/assets/styles/importer.less
+++ b/assets/styles/importer.less
@@ -171,3 +171,11 @@ td h3 {
 .checkbox-inline{
   margin-left: 0 !important;
 }
+
+.editstar{
+  color: red;
+}
+
+.verified{
+  color: green;
+}

--- a/views/home/references.ejs
+++ b/views/home/references.ejs
@@ -35,8 +35,8 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
-            <span ng-if="user.isMod && refUser && reference.verified"><sup><font color="green" title="This trade has been approved and logged by both users.">✓</font></sup></span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font class="editstar" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.verified"><sup><font class="verified" title="This trade has been approved and logged by both users.">✓</font></sup></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -84,8 +84,8 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
-            <span ng-if="user.isMod && refUser && reference.verified"><sup><font color="green" title="This trade has been approved and logged by both users.">✓</font></sup></span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font class="editstar" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.verified"><sup><font class="verified" title="This trade has been approved and logged by both users.">✓</font></sup></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -133,8 +133,8 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
-            <span ng-if="user.isMod && refUser && reference.verified"><sup><font color="green" title="This trade has been approved and logged by both users.">✓</font></sup></span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font class="editstar" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.verified"><sup><font class="verified" title="This trade has been approved and logged by both users.">✓</font></sup></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -214,7 +214,7 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font class="editstar" title="This reference was edited at some point.">*</font></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -264,7 +264,7 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font class="editstar" title="This reference was edited at some point.">*</font></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -314,7 +314,7 @@
           <td>
               <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                      ng-model="reference.approved" ng-if="user.isMod"/>
-              <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
+              <span ng-if="user.isMod && refUser && reference.edited"><font class="editstar" title="This reference was edited at some point.">*</font></span>
           </td>
 
 
@@ -366,7 +366,7 @@
           <td>
               <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                      ng-model="reference.approved" ng-if="user.isMod"/>
-              <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
+              <span ng-if="user.isMod && refUser && reference.edited"><font class="editstar" title="This reference was edited at some point.">*</font></span>
           </td>
 
 

--- a/views/home/references.ejs
+++ b/views/home/references.ejs
@@ -35,7 +35,8 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited">*</span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.verified"><sup><font color="green" title="This trade has been approved and logged by both users.">✓</font></sup></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -83,7 +84,8 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited">*</span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.verified"><sup><font color="green" title="This trade has been approved and logged by both users.">✓</font></sup></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -131,7 +133,8 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited">*</span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
+            <span ng-if="user.isMod && refUser && reference.verified"><sup><font color="green" title="This trade has been approved and logged by both users.">✓</font></sup></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -211,7 +214,7 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited">*</span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -261,7 +264,7 @@
         <td>
             <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                    ng-model="reference.approved" ng-if="user.isMod"/>
-            <span ng-if="user.isMod && refUser && reference.edited">*</span>
+            <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
         </td>
       <td>
         <a href="#viewReferenceModal" data-toggle="modal" ng-click="editReference(reference)" class="icon">
@@ -311,7 +314,7 @@
           <td>
               <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                      ng-model="reference.approved" ng-if="user.isMod"/>
-              <span ng-if="user.isMod && refUser && reference.edited">*</span>
+              <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
           </td>
 
 
@@ -363,7 +366,7 @@
           <td>
               <input type="checkbox" ng-change="approve(reference.id, reference.approved)"
                      ng-model="reference.approved" ng-if="user.isMod"/>
-              <span ng-if="user.isMod && refUser && reference.edited">*</span>
+              <span ng-if="user.isMod && refUser && reference.edited"><font color="red" title="This reference was edited at some point.">*</font></span>
           </td>
 
 


### PR DESCRIPTION
Resolves #4

When a mod approves a User A's trade with User B, the server checks if User B also logged that url in a trade with User A. If they did, user B's version of the trade is also marked as approved. Both versions are also marked as 'verified'. Verified trades display a [green checkmark](https://i.gyazo.com/62cb32c7ad9458b1ce4e4a60036e209b.png) next to the approval box, only visible to mods.

If either user edits their version of the trade, that version of the trade will be un-approved as normal, but the other user's version will remain approved. Both trades will remain verified.

If a mod un-approves either version of the trade, both versions become non-approved and non-verified.

If a version of the trade gets deleted (either by its owner or a mod), the other version will become non-verified, but it will remain approved.

___

This feature only applies to Event, Shiny, and Competitive/Casual trades.