### PR TITLE
Fixed small thing with login

### DIFF
--- a/api/controllers/FlairController.js
+++ b/api/controllers/FlairController.js
@@ -156,7 +156,7 @@ module.exports = {
       var flagged = [];
 
       for (var i = 0; i < flair_FCs.length; i++) {
-        if (!Flairs.isValid(flair_FCs[i])) {
+        if (!Flairs.isValid(flair_FCs[i]) && flair_FCs[i] !== req.user.loggedFriendCodes[i]) {
           flagged.push(flair_FCs[i]);
         }
       }

--- a/config/express.js
+++ b/config/express.js
@@ -4,7 +4,7 @@ var passport = require('passport'),
 var verifyHandler = function (adminToken, token, tokenSecret, profile, done) {
   process.nextTick(function() {
     User.findOne({uid: profile.id}, function(err, user) {
-      Reddit.getBothFlairs(adminToken, profile.name, function (flair1, flair2) {
+      Reddit.getBothFlairs(adminToken, profile.name, function (redditerr, flair1, flair2) {
         if (user) {
           if (user.banned) {
             return done("You are banned from FAPP", user);


### PR DESCRIPTION
Now flair gets set correctly when users log in. (It generally doesn't matter since the flairs get set again when the user loads the index page, but we still shouldn't have buggy code here.) The function was being called with the two flairs in the second and third parameters, but it was checking for the flairs in the first and second parameters.

Also, I fixed something so that modmail spam will be reduced. It will no longer send a modmail if the friendcode matches their most-recently-logged one (i.e. if a modmail was just sent with that friendcode). However, it will send a modmail if the user's FC changes from valid to invalid, or invalid to some-other-invalid.