### PR TITLE
Added modmail search, refactored things

### DIFF
--- a/api/services/Search.js
+++ b/api/services/Search.js
@@ -111,3 +111,29 @@ module.exports.users = function (searchData, cb) {
       });
   });
 };
+
+module.exports.modmails = function (searchData, cb) {
+  var words = searchData.keyword.split(' ');
+  var fields = ['body', 'author', 'subject'];
+  var requirements = [];
+  for (let i = 0; i < words.length; i++) {
+    var current_req = {'$or': []};
+    for (let j = 0; j < fields.length; j++) {
+      let obj = {};
+      obj[fields[j]] = {'contains': words[i]};
+      current_req['$or'].push(obj);
+    }
+    requirements.push(current_req);
+  }
+  //Finds modmails where all of the words in the search query appear somewhere in either the body, subject, or author.
+  var mailData = {
+    limit: 20,
+    skip: searchData.skip ? parseInt(searchData.skip) : 0,
+    sort: 'created_utc DESC',
+    '$and': requirements
+  };
+
+  Modmail.find(mailData).exec(function (err, mail) {
+    cb(mail);
+  });
+};

--- a/assets/search/header.ejs
+++ b/assets/search/header.ejs
@@ -10,8 +10,10 @@
       <div class="input-group">
         <select class="form-control input-group-addon"
                 ng-model="search.input.search"
+                ng-change="search.changeSearchType()"
                 ng-options="item.short as item.name for item in search.searchesForUser()"
-                ng-if="search.searchesForUser().length > 1"></select>
+                ng-if="search.searchesForUser().length > 1">
+        </select>
         <input type="text"
                class="form-control"
                ng-change="search.searchMaybe()"

--- a/assets/search/main.ejs
+++ b/assets/search/main.ejs
@@ -5,7 +5,7 @@
     <div class="content">
       <div class="row">
         <div class="col-md-12">
-          <h2>Advanced Search - <%- searchType %></h2>
+          <h2>Advanced Search - {{search.getSearch().name}}</h2>
         </div>
       </div>
       <div class="row">
@@ -27,10 +27,14 @@
               <%- partial(searchType + '/result.ejs') %>
             </a>
             <a class="list-group-item"
-               ng-if="!search.inProgress"
+               ng-if="!search.inProgress && !search.done"
                ng-click="search.getMore()">
               More results
             </a>
+            <div class="list-group-item"
+               ng-if="search.done">
+              No results past this point
+            </div>
           </ul>
         </div>
       </div>

--- a/assets/search/modmail/controller.js
+++ b/assets/search/modmail/controller.js
@@ -1,0 +1,13 @@
+/* global Search */
+module.exports = function (req, res) {
+  var params = req.allParams();
+  var searchData = {
+    keyword: params.keyword
+  };
+
+  searchData.skip = params.skip || 0;
+
+  Search.modmails(searchData, function (results) {
+    return res.ok(results);
+  });
+};

--- a/assets/search/modmail/form.ejs
+++ b/assets/search/modmail/form.ejs
@@ -1,0 +1,8 @@
+<div class="form-group col-md-3">
+    <label>Search keyword</label>
+    <input type="text" class="form-control" placeholder="Search"
+           ng-change="search.searchMaybe()" ng-model="search.input.keyword"
+           ng-init="search.input.keyword='<%- searchTerm %>'"
+           ng-submit="search.submit()"/>
+    <input type="submit" style="position: absolute; left: -9999px"/>
+</div>

--- a/assets/search/modmail/result.ejs
+++ b/assets/search/modmail/result.ejs
@@ -1,0 +1,6 @@
+<h4 class="list-group-item-heading">
+    {{result.subject}} <em>by /u/{{result.author}}</em>
+</h4>
+<p class="list-group-iitem-text">
+    <strong>{{result.created_utc * 1000 | date:'yyyy-MM-dd HH:mm:ss'}} {{timezoneOffset}}</strong><br>{{result.body}}
+</p>

--- a/assets/search/types.js
+++ b/assets/search/types.js
@@ -1,7 +1,8 @@
 var types = [
-  {"short": "ref", "name": "References", controller: require("./ref/controller.js")},
-  {"short": "user", "name": "Users", controller: require("./user/controller.js")},
-  {"short": "log", "name": "Logs", controller: require("./log/controller.js"), "modOnly": true}
+  {"short": "ref", "name": "References", controller: require("./ref/controller.js"), "modOnly": false},
+  {"short": "user", "name": "Users", controller: require("./user/controller.js"), "modOnly": false},
+  {"short": "log", "name": "Logs", controller: require("./log/controller.js"), "modOnly": true},
+  {"short": "modmail", "name": "Modmails", controller: require("./modmail/controller.js"), "modOnly": true}
 ];
 
 module.exports = types;

--- a/assets/userCtrl.js
+++ b/assets/userCtrl.js
@@ -66,6 +66,8 @@ module.exports = function ($scope, $filter, $location, UserFactory) {
   ];
 
   $scope.onSearchPage = $location.absUrl().indexOf('search') !== -1;
+  let timezone = -new Date().getTimezoneOffset()/60;
+  $scope.timezoneOffset = 'UTC' + (timezone > 0 ? '+' + timezone : timezone < 0 ? timezone : '');
   sharedService.addRepeats($scope);
   $scope.applyFlair = function () {
     $scope.errors.flairApp = "";

--- a/config/policies.js
+++ b/config/policies.js
@@ -55,7 +55,7 @@ module.exports.policies = {
 
   SearchController: {
     '*': mod,
-    refs: user,
+    ref: user,
     refView: user
   },
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -195,7 +195,6 @@ module.exports.routes = {
     controller : 'home',
     action     : 'version'
   }
-
 };
 
 var searchTypes = require("../assets/search/types.js");


### PR DESCRIPTION
Adds modmail search, refactors a few small things, fixes some bugs.

Is there a reason why we have three separate strings (`long`, `short`, and `name`) to describe each search type? It seems like we could simplify things by just using `name` for everything (including the routes and the serverside stuff).