### PR TITLE
Fix #418 and #420

### DIFF
--- a/api/controllers/FlairController.js
+++ b/api/controllers/FlairController.js
@@ -169,8 +169,8 @@ module.exports = {
         }
       });
 
-      var newPFlair = _.get(req, "user.flair.ptrades.flair_css_class", "default");
-      var newsvFlair = _.get(req, "user.flair.svex.flair_css_class", "");
+      var newPFlair = _.get(req, "user.flair.ptrades.flair_css_class") || "default";
+      var newsvFlair = _.get(req, "user.flair.svex.flair_css_class") || "";
       newsvFlair = newsvFlair.replace(/2/, "");
       var promises = [];
       promises.push(Reddit.setFlair(refreshToken, req.user.name, newPFlair, flairs.ptrades, "PokemonTrades"));

--- a/assets/js/userCtrl.js
+++ b/assets/js/userCtrl.js
@@ -72,7 +72,7 @@ module.exports = function ($scope, $filter, $location, UserFactory) {
     $scope.userok.applyFlair = false;
     $scope.userspin.applyFlair = true;
     var flair = $scope.getFlair($scope.selectedFlair, $scope.flairs);
-    if ($scope.selectedFlair && $scope.canUserApply($scope.user, flair, $scope.flairs)) {
+    if ($scope.selectedFlair && $scope.canUserApply(flair)) {
       io.socket.post("/flair/apply", {flair: $scope.selectedFlair, sub: flair.sub}, function (data, res) {
         if (res.statusCode === 200) {
           $scope.user.apps.push(data);


### PR DESCRIPTION
* #418: People with default flair on svex can't set their flair text
* #420: No one can apply for flair

___
* Cause of 418: lodash.get uses the default case when the path is `undefined`, but we want the default case to get used whenever the path is falsey. It's running into trouble when the flair css class is `null`.
* Cause of 420: Messed-up function call from clientside refactor